### PR TITLE
Split words of user input, remove punctuation

### DIFF
--- a/zxcvbn/__init__.py
+++ b/zxcvbn/__init__.py
@@ -1,3 +1,4 @@
+import re
 import time
 from datetime import timedelta
 from decimal import Decimal
@@ -9,8 +10,14 @@ from . import feedback, matching, scoring, time_estimates, types
 def zxcvbn(password: str, user_inputs: Iterable[str] = None) -> types.Feedback:
     start = time.perf_counter()
 
-    # Find unique non-empty user inputs, lower-cased, preserving original order
-    sanitized_inputs = list(dict.fromkeys(s.lower() for s in user_inputs or [] if s))
+    # Find unique non-empty user inputs, split words lower-cased, preserving order
+    wordsep = re.compile(r"\W+|_")
+    sanitized_inputs = list(dict.fromkeys(
+        s.lower()
+        for u in user_inputs or []
+        for s in re.split(wordsep, u)
+        if s
+    ))
     ranked_dictionaries = matching.RANKED_DICTIONARIES
     ranked_dictionaries["user_inputs"] = matching.build_ranked_dict(sanitized_inputs)
 


### PR DESCRIPTION
Implements smarter splitting of user inputs, suitable for use with user registration forms and other texts where the words may not be properly split by default.

For example:
```python
user_inputs=['Nicolás Garcia', 'bossman@garcia-jenkins.com']

# Original implementation gives
['nicolás garcia', 'bossman@garcia-jenkins.com']

# With this patch
['nicolás', 'garcia', 'bossman', 'jenkins', 'com']
```

With this patch a password such as `NicolásGarciaBossman` is properly recognised as weak, while previously it would match none of the user input given.
